### PR TITLE
feat: add generic home page section generation

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -114,254 +114,297 @@ params:
       enable : true
       showOnScrollUp : true
     enableSeparator: false
-    menus:
-      disableAbout: false
-      disableExperience: false
-      disableEducation: false
-      disableProjects: false
-      disableAchievements: false
-      disableContact: false
 
-  # Hero
-  hero:
-    enable: true
-    intro: "Hi, my name is"
-    title: "Isabella."
-    subtitle: "I build things for the web"
-    content: "A passionate web app developer. I tend to make use of modern web technologies to build websites that looks great, feels fantastic, and functions correctly."
-    image: /images/hero.svg
-    bottomImage:
+  sections:
+    # Hero
+    - type: hero
       enable: true
-    # roundImage: true # Make hero image circular | default false
-    button:
-      enable: true
-      name: "Resume"
-      url: "#"
-      download: true
-      newPage: false
-    socialLinks:
-      fontAwesomeIcons:
-        - icon: fab fa-github
-          url: https://example.com
-        - icon: fab fa-x-twitter
-          url: https://example.com
-      customIcons:
-        - icon: /fav.png
-          url: "https://example.com"
+      intro: "Hi, my name is"
+      title: "Isabella."
+      subtitle: "I build things for the web"
+      content: |
+        A passionate web app developer. I tend to make use of modern web
+        technologies to build websites that looks great, feels fantastic, and
+        functions correctly.
+      image: /images/hero.svg
+      bottomImage:
+        enable: true
+      # roundImage: true # Make hero image circular | default false
+      button:
+        enable: true
+        name: "Resume"
+        url: "#"
+        download: true
+        newPage: false
+      socialLinks:
+        fontAwesomeIcons:
+          - icon: fab fa-github
+            url: https://example.com
+          - icon: fab fa-x-twitter
+            url: https://example.com
+        customIcons:
+          - icon: /fav.png
+            url: "https://example.com"
 
-  # About
-  about:
-    enable: true
-    title: "About Me"
-    image: "/images/me.png"
-    content: |-
-      I am a software developer with a passion for web development. I have a background in computer science and mathematics, and I have a strong interest in the intersection of technology and art. I am currently working as a software developer at [example org.](https://example.com) in San Francisco, CA.
-
-      I am currently working on a project that will be used to help people find the best way to get around the city.
-    skills:
+    # About
+    - type: about
       enable: true
-      title: "Here are a few technologies I've been working with recently:"
+      showInNavbar: true
+      title: "About Me"
+      # id: about-me  # Custom ID (used for navbar)
+      image: "/images/me.png"
+      content: |
+        I am a software developer with a passion for web development. I have a
+        background in computer science and mathematics, and I have a strong
+        interest in the intersection of technology and art. I am currently
+        working as a software developer at [example org.](https://example.com)
+        in San Francisco, CA.
+
+        I am currently working on a project that will be used to help people
+        find the best way to get around the city.
+      skills:
+        enable: true
+        title: "Here are a few technologies I've been working with recently:"
+        items:
+          - "HTML"
+          - "CSS"
+          - "JavaScript"
+          - "React"
+          - "Node"
+          - "Express"
+
+    # Experience
+    - type: experience
+      enable: true
+      showInNavbar: true
+      # title: "Custom Name"
       items:
-        - "HTML"
-        - "CSS"
-        - "JavaScript"
-        - "React"
-        - "Node"
-        - "Express"
+        - job: "Senior Software Developer"
+          company: "Facebook"
+          companyUrl: "https://example.com"
+          date: "Jan 2022 - present"
+          featuredLink:
+            enable: true
+            name: "View the project"
+            url: "https://example.com"
+          content: |
+            I am currently working as a software developer at [example
+            org.](https://example.com) in San Francisco, CA. I am currently
+            working on a project that will be used to help people find the best
+            way to get around the city."
 
-  # Experience
-  experience:
-    enable: true
-    # title: "Custom Name"
-    items:
-      - job: "Senior Software Developer"
-        company: "Facebook"
-        companyUrl: "https://example.com"
-        date: "Jan 2022 - present"
-        featuredLink:
-          enable: true
-          name: "View the project"
-          url: "https://example.com"
-        content: "I am currently working as a software developer at [example org.](https://example.com) in San Francisco, CA. I am currently working on a project that will be used to help people find the best way to get around the city."
+        - job: "Software Developer"
+          company: "Amazon"
+          companyUrl: "https://example.com"
+          date: "Sep 2020 - Dec 2021"
+          featuredLink:
+            enable: true
+            url: "https://example.com"
+          info:
+            enable: true
+            content: |
+              I worked as a software developer for more than one year in Amazon.
+          content: |
+            I am currently working as a software developer at [example
+            org.](https://example.com) in San Francisco, CA. I am currently
+            working on a project that will be used to help people find the best
+            way to get around the city.
 
-      - job: "Software Developer"
-        company: "Amazon"
-        companyUrl: "https://example.com"
-        date: "Sep 2020 - Dec 2021"
-        featuredLink:
-          enable: true
-          url: "https://example.com"
-        info:
-          enable: true
-          content: I worked as a software developer for more than one year in Amazon.
-        content: |
-          I am currently working as a software developer at [example org.](https://example.com) in San Francisco, CA. I am currently working on a project that will be used to help people find the best way to get around the city.
+            - Lead backend developer for a product.
+            - Created a frontend design for a product.
 
-          - Lead backend developer for a product.
-          - Created a frontend design for a product.
+        - job: "Junior Software Developer"
+          company: "Apple"
+          companyUrl: "https://example.com"
+          date: "Jan 2020 - Aug 2020"
+          info:
+            enable: false
+          featuredLink:
+            enable: true
+            url: "https://example.com"
+          content: |
+            I am currently working as a software developer at [example
+            org.](https://example.com) in San Francisco, CA. I am currently
+            working on a project that will be used to help people find the best
+            way to get around the city.
 
-      - job: "Junior Software Developer"
-        company: "Apple"
-        companyUrl: "https://example.com"
-        date: "Jan 2020 - Aug 2020"
-        info:
-          enable: false
-        featuredLink:
-          enable: true
-          url: "https://example.com"
-        content: |
-          I am currently working as a software developer at [example org.](https://example.com) in San Francisco, CA. I am currently working on a project that will be used to help people find the best way to get around the city.
+            - Lead backend developer for a product.
+            - Created a frontend design for a product.
 
-          - Lead backend developer for a product.
-          - Created a frontend design for a product.
+        - job: "UI/UX Designer"
+          company: "Netflix"
+          companyUrl: "https://example.com"
+          date: "June 2017 - Nov 2019"
+          featuredLink:
+            enable: true
+            url: "https://example.com"
+          content: |
+            I am currently working as a software developer at [example
+            org.](https://example.com) in San Francisco, CA. I am currently
+            working on a project that will be used to help people find the best
+            way to get around the city.
 
-      - job: "UI/UX Designer"
-        company: "Netflix"
-        companyUrl: "https://example.com"
-        date: "June 2017 - Nov 2019"
-        featuredLink:
-          enable: true
-          url: "https://example.com"
-        content: |
-          I am currently working as a software developer at [example org.](https://example.com) in San Francisco, CA. I am currently working on a project that will be used to help people find the best way to get around the city.
+            - Lead backend developer for a product.
+            - Created a frontend design for a product.
 
-          - Lead backend developer for a product.
-          - Created a frontend design for a product.
+        - job: "Product Designer"
+          company: "Google"
+          companyUrl: "https://example.com"
+          date: "Feb 2016 - Mar 2017"
+          content: |
+            I am currently working as a software developer at [example
+            org.](https://example.com) in San Francisco, CA. I am currently
+            working on a project that will be used to help people find the best
+            way to get around the city.
 
-      - job: "Product Designer"
-        company: "Google"
-        companyUrl: "https://example.com"
-        date: "Feb 2016 - Mar 2017"
-        content: "I am currently working as a software developer at [example org.](https://example.com) in San Francisco, CA. I am currently working on a project that will be used to help people find the best way to get around the city."
+    # Education
+    - type: education
+      enable: true
+      showInNavbar: true
+      # title: "Custom Name"
+      index: false
+      items:
+        - title: "Master of Business Administration"
+          school:
+            name: "University of California, Berkeley"
+            url: "https://example.org"
+          date: "2013 - 2015"
+          GPA: "3.8 out of 5.0"
+          content: |-
+            Extracurricular Activities:
 
-  # Education
-  education:
-    enable: true
-    # title: "Custom Name"
-    index: false
-    items:
-      - title: "Master of Business Administration"
-        school:
-          name: "University of California, Berkeley"
-          url: "https://example.org"
-        date: "2013 - 2015"
-        GPA: "3.8 out of 5.0"
-        content: |-
-          Extracurricular Activities
             - Lorem ipsum dolor sit amet consectetur adipisicing elit.
-            - Tempora esse, eaque delectus nulla quo doloribus itaque expedita alias natus optio totam maxime nihil excepturi velit a animi laborum hic similique.
-      - title: "Bachelor of Science in Computer Science"
-        school:
-          name: "Massachusetts Institute of Technology"
-          url: "https://example.org"
-        date: "2009 - 2013"
-        GPA: "3.9 out of 5.0"
-        content: |-
-          I Publiced two papers in the ACM SIGCHI Conference on Artificial Intelligence.
-          - [Fast and Accurate Object Detection with a Single Convolutional Neural Network](https://example.com)
-          - Face mask detection using a single convolutional neural network.
+            - Tempora esse, eaque delectus nulla quo doloribus itaque expedita
+              alias natus optio totam maxime nihil excepturi velit a animi
+              laborum hic similique.
+        - title: "Bachelor of Science in Computer Science"
+          school:
+            name: "Massachusetts Institute of Technology"
+            url: "https://example.org"
+          date: "2009 - 2013"
+          GPA: "3.9 out of 5.0"
+          content: |-
+            I Publiced two papers in the ACM SIGCHI Conference on Artificial
+            Intelligence:
 
-          Extracurricular Activities
+            - [Fast and Accurate Object Detection with a Single Convolutional
+              Neural Network](https://example.com)
+            - Face mask detection using a single convolutional neural network.
+
+            Extracurricular Activities:
+
             - Lorem ipsum dolor sit amet consectetur adipisicing elit.
-            - Tempora esse, eaque delectus nulla quo doloribus itaque expedita alias natus optio totam maxime nihil excepturi velit a animi laborum hic similique.
-        featuredLink:
-          enable: true
-          name: "My academic record"
-          url: "https://example.com"
-      - title: "High School"
-        school:
-          name: "Thomas Jefferson High School for Science and Technology."
-          url: "https://example.org"
-        GPA: "4.2 out of 5.0"
-        featuredLink:
-          enable: true
-          url: "https://example.com"
+            - Tempora esse, eaque delectus nulla quo doloribus itaque expedita
+              alias natus optio totam maxime nihil excepturi velit a animi
+              laborum hic similique.
+          featuredLink:
+            enable: true
+            name: "My academic record"
+            url: "https://example.com"
+        - title: "High School"
+          school:
+            name: "Thomas Jefferson High School for Science and Technology."
+            url: "https://example.org"
+          GPA: "4.2 out of 5.0"
+          featuredLink:
+            enable: true
+            url: "https://example.com"
 
-  # Achievements
-  achievements:
-    enable: true
-    # title: "Custom Name"
-    items:
-      - title: Google kickstart runner
-        content: I solved all problems with optimal solution.
-        url: https://example.com
-        image: /images/achievment.jpg
-      - title: Facebook Hackathon Winner
-        content: Developed a product using Artificial Intelligence.
-        image: /images/achievment.jpg
-      - title: Hugo Profile
-        content: Developed a theme and getting 1K+ downloads per month.
-        url: "https://github.com/gurusabarish/hugo-profile"
-        image: /images/achievment.jpg
-      - title: Microsoft Imagine Runner
-        content: We are developed a product which can help others.
-      - title: Google Summer of Code
-        content: Contributed to a open source project.
-        url: https://example.com
+    # Achievements
+    - type: achievements
+      enable: true
+      showInNavbar: true
+      # title: "Custom Name"
+      items:
+        - title: Google kickstart runner
+          content: I solved all problems with optimal solution.
+          url: https://example.com
+          image: /images/achievment.jpg
+        - title: Facebook Hackathon Winner
+          content: Developed a product using Artificial Intelligence.
+          image: /images/achievment.jpg
+        - title: Hugo Profile
+          content: Developed a theme and getting 1K+ downloads per month.
+          url: "https://github.com/gurusabarish/hugo-profile"
+          image: /images/achievment.jpg
+        - title: Microsoft Imagine Runner
+          content: We are developed a product which can help others.
+        - title: Google Summer of Code
+          content: Contributed to a open source project.
+          url: https://example.com
 
-  # projects
-  projects:
-    enable: true
-    # title: "Custom Name"
-    items:
-      - title: Hugo Profile
-        content: A highly customizable and mobile first Hugo template for personal portfolio and blog.
-        image: /images/projects/profile.png
-        featured:
-          name: Demo
-          link: https://hugo-profile.netlify.app
-        badges:
-          - "Hugo"
-          - "Bootstrap"
-          - "Javascript"
-        links:
-          - icon: fa fa-envelope
-            url: mailto:?subject=Hugo%20Profile%20Template&body=Check%20it%20out:%20https%3a%2f%2fhugo-profile.netlify.app%2fblog%2fmarkdown-syntax%2f
-          - icon: fab fa-github
-            url: https://github.com/gurusabarish/hugo-profile
-          - icon: fab fa-twitter
-            url: https://twitter.com/intent/tweet?text=Check+it+out:&url=https%3A%2F%2Fgithub.com%2Fgurusabarish%2Fhugo-profile
+    # Projects
+    - type: projects
+      enable: true
+      showInNavbar: true
+      # title: "Custom Name"
+      items:
+        - title: Hugo Profile
+          content: |
+            A highly customizable and mobile first Hugo template for personal
+            portfolio and blog.
+          image: /images/projects/profile.png
+          featured:
+            name: Demo
+            link: https://hugo-profile.netlify.app
+          badges:
+            - "Hugo"
+            - "Bootstrap"
+            - "Javascript"
+          links:
+            - icon: fa fa-envelope
+              url: mailto:?subject=Hugo%20Profile%20Template&body=Check%20it%20out:%20https%3a%2f%2fhugo-profile.netlify.app%2fblog%2fmarkdown-syntax%2f
+            - icon: fab fa-github
+              url: https://github.com/gurusabarish/hugo-profile
+            - icon: fab fa-twitter
+              url: https://twitter.com/intent/tweet?text=Check+it+out:&url=https%3A%2F%2Fgithub.com%2Fgurusabarish%2Fhugo-profile
 
-      - title: Image Converter
-        content: A web app to convert image to pdf, png to jpg, png to jpg and png to webp without database using django.
-        image: /images/projects/converter.jpg
-        featured:
-          name: Demo
-          link: https://django-converter.herokuapp.com
-        badges:
-          - "Django"
-          - "Bootstrap"
-        links:
-          - icon: fab fa-github
-            url: https://github.com/gurusabarish/converter
+        - title: Image Converter
+          content: |
+            A web app to convert image to pdf, png to jpg, png to jpg and png to
+            webp without database using django.
+          image: /images/projects/converter.jpg
+          featured:
+            name: Demo
+            link: https://django-converter.herokuapp.com
+          badges:
+            - "Django"
+            - "Bootstrap"
+          links:
+            - icon: fab fa-github
+              url: https://github.com/gurusabarish/converter
 
-      - title: Hugo Profile V2
-        content: A clean and simple Hugo template for personal portfolio and blog.
-        image: /images/projects/profile2.jpg
-        featured:
-          name: Demo V2
-          link: https://hugo-profile-2.netlify.app
-        badges:
-          - "Hugo"
-          - "Bootstrap"
-          - "Javascript"
-        links:
-          - icon: fab fa-github
-            url: https://github.com/gurusabarish/HugoProfileV2
+        - title: Hugo Profile V2
+          content: |
+            A clean and simple Hugo template for personal portfolio and blog.
+          image: /images/projects/profile2.jpg
+          featured:
+            name: Demo V2
+            link: https://hugo-profile-2.netlify.app
+          badges:
+            - "Hugo"
+            - "Bootstrap"
+            - "Javascript"
+          links:
+            - icon: fab fa-github
+              url: https://github.com/gurusabarish/HugoProfileV2
 
-  #Contact
-  contact:
-    enable: true
-    # title: "Custom Name"
-    content: My inbox is always open. Whether you have a question or just want to say hi, I’ll try my best to get back to you!
-    btnName: Mail me
-    btnLink: mailto:gurusabarisha@gmail.com
-    # formspree:
-    #   enable: true # `contact.email` value will be ignored
-    #   formId: abcdefgh # Take it from your form's endpoint, like 'https://formspree.io/f/abcdefgh'
-    #   emailCaption: "Enter your email address"
-    #   messageCaption: "Enter your message here"
-    #   messageRows: 5
+    # Contact
+    - type: contact
+      enable: true
+      showInNavbar: true
+      # title: "Custom Name"
+      content: |
+        My inbox is always open. Whether you have a question or just want to say
+        hi, I’ll try my best to get back to you!
+      btnName: Mail me
+      btnLink: mailto:gurusabarisha@gmail.com
+      # formspree:
+      #   enable: true # `contact.email` value will be ignored
+      #   formId: abcdefgh # Take it from your form's endpoint, like 'https://formspree.io/f/abcdefgh'
+      #   emailCaption: "Enter your email address"
+      #   messageCaption: "Enter your message here"
+      #   messageRows: 5
 
   footer:
     recentPosts:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,11 +12,22 @@
 {{ end }}
 
 {{ define "main" }}
-{{- partial "sections/hero/index.html" . -}}
-{{- partial "sections/about.html" . -}}
-{{- partial "sections/experience.html" . -}}
-{{- partial "sections/education.html" . -}}
-{{- partial "sections/projects.html" . -}}
-{{- partial "sections/achievements.html" . -}}
-{{- partial "sections/contact.html" . -}}
+    {{ range $index, $element := (where .Site.Params.sections "enable" true) }}
+        {{ if not .type }}
+            {{ errorf "Type property needs to be set for section with index %d." $index }}
+        {{ else }}
+            {{ with $element }}
+                {{ $partialPathIndex := printf "sections/%s/index.html" .type }}
+                {{ $partialPathStandalone := printf "sections/%s.html" .type }}
+
+                {{ if templates.Exists (printf "partials/%s" $partialPathIndex) }}
+                    {{- partial $partialPathIndex . -}}
+                {{ else if templates.Exists (printf "partials/%s" $partialPathStandalone) }}
+                    {{- partial $partialPathStandalone . -}}
+                {{ else }}
+                    {{ errorf "Cannot find partial for section type: %s" .type }}
+                {{ end }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
 {{ end }}

--- a/layouts/partials/sections/about.html
+++ b/layouts/partials/sections/about.html
@@ -1,28 +1,26 @@
-{{ if .Site.Params.about.enable | default false }}
-<section id="about" class="py-0 py-sm-5">
+<section id="{{ .id | default .type }}" class="about py-0 py-sm-5">
     <div class="container bg-transparent">
-        <h3 class="text-center bg-transparent">{{ .Site.Params.about.title }}</h3>
+        <h3 class="text-center bg-transparent">{{ .title | default (strings.FirstUpper .type) }}</h3>
         <div class="bg-transparent row justify-content-center px-3 py-5">
-            {{ if .Site.Params.about.image }}
-            <div class="col-sm-12 col-md-8 col-lg-4 mb-5 mb-sm-0 mb-md-5 mb-lg-0 d-none d-sm-none d-md-block">
-                <div class="image d-flex px-5">
-                    <img src="{{ .Site.Params.about.image }}" class="img-thumbnail mx-auto rounded-circle" alt="">
+            {{ if .image }}
+                <div class="col-sm-12 col-md-8 col-lg-4 mb-5 mb-sm-0 mb-md-5 mb-lg-0 d-none d-sm-none d-md-block">
+                    <div class="image d-flex px-5">
+                        <img src="{{ .image }}" class="img-thumbnail mx-auto rounded-circle" alt="">
+                    </div>
                 </div>
-            </div>
             {{ end }}
             <div class="col-sm-12 col-md-12 col-lg-8 content">
-                {{ .Site.Params.about.content | markdownify }}
+                {{ .content | markdownify }}
 
-                {{ if .Site.Params.about.skills.enable }}
-                {{ .Site.Params.about.skills.title }}
-                <ul>
-                    {{ range .Site.Params.about.skills.items }}
-                    <li>{{ . | markdownify }}</li>
-                    {{ end }}
-                </ul>
+                {{ if .skills.enable }}
+                    {{ .skills.title }}
+                    <ul>
+                        {{ range .skills.items }}
+                            <li>{{ . | markdownify }}</li>
+                        {{ end }}
+                    </ul>
                 {{ end }}
             </div>
         </div>
     </div>
 </section>
-{{ end }}

--- a/layouts/partials/sections/achievements.html
+++ b/layouts/partials/sections/achievements.html
@@ -1,10 +1,9 @@
-{{ if .Site.Params.achievements.enable | default false }}
-<section id="achievements" class="py-5">
+<section id="{{ .id | default .type }}" class="achievements py-5">
     <div class="container">
-        <h3 class="text-center">{{ .Site.Params.achievements.title | default "Achievements" }}</h3>
+        <h3 class="text-center">{{ .title | default (strings.FirstUpper .type) }}</h3>
         <div class="px-0 px-md-5 px-lg-5">
             <div class="row justify-content-center px-3 px-md-5 px-lg-5">
-                {{ range .Site.Params.achievements.items }}
+                {{ range .items }}
                 {{ if .url }}
                 <div class="col-lg-4 col-md-6 my-3">
                     <a class="card my-3 h-100 p-3" href="{{ .url }}" title="{{ .title }}" target="_blank">
@@ -43,4 +42,3 @@
         </div>
     </div>
 </section>
-{{ end }}

--- a/layouts/partials/sections/contact.html
+++ b/layouts/partials/sections/contact.html
@@ -1,39 +1,38 @@
-{{ if .Site.Params.contact.enable | default false }}
-<section id="contact" class="py-5">
+<section id="{{ .id | default .type }}" class="contact py-5">
     <div class="container">
-        <h3 class="text-center">{{ .Site.Params.contact.title | default "Get in Touch" }}</h3>
+        <h3 class="text-center">{{ .title | default (strings.FirstUpper .type) }}</h3>
         <div class="px-0 px-md-5 px-lg-5">
             <div class="row justify-content-center px-md-5">
                 <div class="col-md-8 py-3">
                     <div class="text-center">
-                        {{ .Site.Params.contact.content | emojify | markdownify }}
+                        {{ .content | emojify | markdownify }}
                     </div>
-                    {{ if .Site.Params.contact.formspree.enable | default false }}
+                    {{ if .formspree.enable | default false }}
                     <div class="row justify-content-center">
-                        <form id="contact-form" action="https://formspree.io/f/{{ .Site.Params.contact.formspree.formId }}" onsubmit="handleFormspreeSubmit(event)" method="POST" class="col-md-7">
+                        <form id="contact-form" action="https://formspree.io/f/{{ .formspree.formId }}" onsubmit="handleFormspreeSubmit(event)" method="POST" class="col-md-7">
                             <div class="form-group pt-3">
-                                <input type="email" class="form-control"  name="email" required="true" placeholder='{{ .Site.Params.contact.formspree.emailCaption | emojify | default "Enter your email" }}'>
+                                <input type="email" class="form-control"  name="email" required="true" placeholder='{{ .formspree.emailCaption | emojify | default "Enter your email" }}'>
                             </div>
                             <div class="form-group pt-3">
-                                <textarea class="form-control" name="message" required="true" placeholder='{{ .Site.Params.contact.formspree.messageCaption | emojify | default "Enter your message" }}' rows="{{ .Site.Params.contact.formspree.messageRows | default 3 }}"></textarea>
+                                <textarea class="form-control" name="message" required="true" placeholder='{{ .formspree.messageCaption | emojify | default "Enter your message" }}' rows="{{ .formspree.messageRows | default 3 }}"></textarea>
                             </div>
                             <div class="form-group text-center pt-3">
-                                <button type="submit" class="btn">{{ .Site.Params.contact.btnName | default "Get in Touch" }}</button>
+                                <button type="submit" class="btn">{{ .btnName | default "Get in Touch" }}</button>
                             </div>
                         </form>
                     </div>
-                    {{ else if or (.Site.Params.contact.email)  (.Site.Params.contact.btnLink) }}
+                    {{ else if or .email .btnLink }}
                     <div class="text-center pt-3">
-                        <a 
-                            href='{{ if .Site.Params.contact.btnLink }}
-                                    {{ .Site.Params.contact.btnLink | default "#" }}
-                                  {{ else }}
-                                    mailto:{{ .Site.Params.contact.email }}
-                                  {{ end }}'
+                        <a
+                            href='{{ if .btnLink }}
+                                    {{ .btnLink | default "#" }}
+                                {{ else }}
+                                    mailto:{{ .email }}
+                                {{ end }}'
                             target="_blank"
                             class="btn"
                         >
-                            {{ .Site.Params.contact.btnName | default "Get in Touch" }}
+                            {{ .btnName | default "Get in Touch" }}
                         </a>
                     </div>
                     {{ end }}
@@ -43,7 +42,6 @@
     </div>
     <div id="contact-form-status"></div>
 </section>
-{{ end }}
 
 <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
   <symbol id="check-circle-fill" viewBox="0 0 16 16">

--- a/layouts/partials/sections/education.html
+++ b/layouts/partials/sections/education.html
@@ -1,10 +1,9 @@
-{{ if .Site.Params.education.enable | default false }}
-<section id="education" class="py-5">
+<section id="{{ .id | default .type }}" class="education py-5">
     <div class="container">
-        <h3 class="text-center">{{ .Site.Params.education.title | default "Education" }}</h3>
+        <h3 class="text-center">{{ .title | default (strings.FirstUpper .type) }}</h3>
         <div class="row justify-content-center py-5">
-            {{ $indexMenu := .Site.Params.education.index }}
-            {{ range $index, $element := .Site.Params.education.items }}
+            {{ $indexMenu := .index }}
+            {{ range $index, $element := .items }}
             <div class="col-12 p-0">
                 <div class="row row align-items-center justify-content-center m-1 mb-4">
                     {{ if $indexMenu }}
@@ -24,7 +23,7 @@
                                     <small>{{ .date }}</small>
                                 </div>
                                 <h5 class="card-title">{{ .title }}</h5>
-                                
+
                                 {{ if .school.url }}
                                 <a href="{{ .school.url }}" target="_blank">
                                     <h6>
@@ -40,7 +39,7 @@
                                     GPA:
                                     <i>
                                         <small>{{ .GPA }}</small>
-                                    </i> 
+                                    </i>
                                 </div>
                                 {{ end }}
                                 <div class="py-1 education-content">
@@ -63,4 +62,3 @@
         </div>
     </div>
 </section>
-{{ end }}

--- a/layouts/partials/sections/experience.html
+++ b/layouts/partials/sections/experience.html
@@ -1,35 +1,34 @@
-{{ if .Site.Params.experience.enable | default false }}
-<section id="experience" class="py-5">
+<section id="{{ .id | default .type }}" class="experience py-5">
     <div class="container">
-        <h3 class="text-center">{{ .Site.Params.experience.title | default "Experience" }}</h3>
+        <h3 class="text-center">{{ .title | default (strings.FirstUpper .type) }}</h3>
         <div class="row justify-content-center">
             <div class="col-sm-12 col-md-8 col-lg-8 py-5">
                 <div class="experience-container px-3 pt-2">
                     <ul class="nav nav-pills mb-3 bg-transparent primary-font" id="pills-tab" role="tablist">
-                        {{ range $index, $element := .Site.Params.experience.items }}
+                        {{ range $index, $element := .items }}
                         {{ if (eq $index 0) }}
                         <li class="nav-item px-1 bg-transparent" role="presentation">
-                            <div 
-                                class="nav-link active bg-transparent" 
-                                aria-selected="true" 
-                                role="tab" 
+                            <div
+                                class="nav-link active bg-transparent"
+                                aria-selected="true"
+                                role="tab"
                                 data-bs-toggle="pill"
                                 id='{{ replace .company " " "-" }}-{{ replace .date " " "-" }}-tab'
                                 data-bs-target='#pills-{{ replace .company " " "-" }}-{{ replace .date " " "-" }}'
-                                aria-controls='{{ replace .company " " "-" }}-{{ replace .date " " "-" }}' 
+                                aria-controls='{{ replace .company " " "-" }}-{{ replace .date " " "-" }}'
                             >
                                 {{ .company }}
                             </div>
                         </li>
                         {{ else }}
                         <li class="nav-item px-1 bg-transparent" role="presentation">
-                            <div 
-                                class="nav-link bg-transparent" 
-                                aria-selected="true" 
-                                role="tab" 
+                            <div
+                                class="nav-link bg-transparent"
+                                aria-selected="true"
+                                role="tab"
                                 data-bs-toggle="pill"
                                 id='{{ replace .company " " "-" }}-{{ replace .date " " "-" }}-tab'
-                                data-bs-target='#pills-{{ replace .company " " "-" }}-{{ replace .date " " "-" }}' 
+                                data-bs-target='#pills-{{ replace .company " " "-" }}-{{ replace .date " " "-" }}'
                                 aria-controls='{{ replace .company " " "-" }}-{{ replace .date " " "-" }}'
                             >
                                 {{ .company }}
@@ -39,10 +38,10 @@
                         {{ end }}
                     </ul>
                     <div class="tab-content pb-5 pt-2 bg-transparent primary-font" id="pills-tabContent">
-                        {{ range $index, $element := .Site.Params.experience.items }}
+                        {{ range $index, $element := .items }}
                         {{ if (eq $index 0) }}
-                        <div 
-                            class="tab-pane fade show active bg-transparent" 
+                        <div
+                            class="tab-pane fade show active bg-transparent"
                             role="tabpanel"
                             id='pills-{{ replace .company " " "-" }}-{{ replace .date " " "-" }}'
                             aria-labelledby='pills-{{ replace .company " " "-" }}-{{ replace .date " " "-" }}-tab'
@@ -55,10 +54,10 @@
                                     <small>{{ .date }}</small>
                                     {{ if .info.enable | default true }}
                                     <span class="p-2">
-                                        <span 
-                                            style="cursor: pointer;" 
-                                            data-bs-toggle="tooltip" 
-                                            data-bs-placement="top" 
+                                        <span
+                                            style="cursor: pointer;"
+                                            data-bs-toggle="tooltip"
+                                            data-bs-placement="top"
                                             data-bs-original-title={{ .info.content | default (print "Working as a " .job " at " .company ) }}
                                         >
                                             <i class="fas fa-info-circle fa-xs"></i>
@@ -70,7 +69,7 @@
                                 {{ if .featuredLink.enable | default false }}
                                 <div class="py-2 featuredLink">
                                     <a class="p-2 px-4 btn btn-outline-primary btn-sm" href={{ .featuredLink.url | default "#" }} target="_blank">
-                                        {{ .featuredLink.name | default "Featured Link" }} 
+                                        {{ .featuredLink.name | default "Featured Link" }}
                                     </a>
                                 </div>
                                 {{ end }}
@@ -79,8 +78,8 @@
                             {{ .content | markdownify}}
                         </div>
                         {{ else }}
-                        <div 
-                            class="tab-pane fade bg-transparent" 
+                        <div
+                            class="tab-pane fade bg-transparent"
                             role="tabpanel"
                             id='pills-{{ replace .company " " "-" }}-{{ replace .date " " "-" }}'
                             aria-labelledby='pills-{{ replace .company " " "-" }}-{{ replace .date " " "-" }}-tab'
@@ -89,27 +88,27 @@
                                 <span class="h4">{{ .job }}</span>
                                 <small>-</small>
                                 <a href="{{ .companyUrl }}" target="_blank">{{ .company }}</a>
-                                
+
                                 <div class="pb-1">
                                     <small>{{ .date }}</small>
                                     {{ if .info.enable | default true }}
                                     <span class="p-2">
-                                        <span 
-                                            style="cursor: pointer;" 
-                                            data-bs-toggle="tooltip" 
-                                            data-bs-placement="top" 
+                                        <span
+                                            style="cursor: pointer;"
+                                            data-bs-toggle="tooltip"
+                                            data-bs-placement="top"
                                             data-bs-original-title={{ .info.content | default (print "Worked as a " .job " at " .company ) }}
-                                        > 
+                                        >
                                             <i class="fas fa-info-circle fa-xs"></i>
                                         </span>
                                     </span>
                                     {{ end }}
                                 </div>
-                                
+
                                 {{ if .featuredLink.enable | default false }}
                                 <div class="py-2 featuredLink">
                                     <a class="p-2 px-4 btn btn-outline-primary btn-sm" href={{ .featuredLink.url | default "#" }} target="_blank">
-                                        {{ .featuredLink.name | default "Featured Link" }} 
+                                        {{ .featuredLink.name | default "Featured Link" }}
                                     </a>
                                 </div>
                                 {{ end }}
@@ -127,4 +126,3 @@
         </div>
     </div>
 </section>
-{{ end }}

--- a/layouts/partials/sections/header.html
+++ b/layouts/partials/sections/header.html
@@ -86,57 +86,17 @@
                         </li>
                     {{ end }}
 
-                    {{ if and (.Site.Params.about.enable | default false) (not (.Site.Params.navbar.menus.disableAbout | default false)) }}
-                    <li class="nav-item navbar-text">
-                        <a class="nav-link" href="{{ .Site.BaseURL | relURL }}#about" aria-label="about">
-                            {{ .Site.Params.about.title | default "About" }}
-                        </a>
-                    </li>
-                    {{ end }}
+                    {{ range (where (where .Site.Params.sections "enable" true) "showInNavbar" true) }}
+                        {{ if and (.type) (not (eq .type "hero")) }}
+                            {{ $id := (.id | default .type) }}
+                            {{ $title := (.title | default (strings.FirstUpper .type)) }}
 
-                    {{ if and (.Site.Params.experience.enable | default false) (not (.Site.Params.navbar.menus.disableExperience | default false)) }}
-                    <li class="nav-item navbar-text">
-                        <a class="nav-link" href="{{ .Site.BaseURL | relURL }}#experience"
-                            aria-label="experience">
-                            {{ .Site.Params.experience.title | default "Experience" }}
-                        </a>
-                    </li>
-                    {{ end }}
-
-                    {{ if and (.Site.Params.education.enable | default false) (not (.Site.Params.navbar.menus.disableEducation | default false)) }}
-                    <li class="nav-item navbar-text">
-                        <a class="nav-link" href="{{ .Site.BaseURL | relURL }}#education"
-                            aria-label="education">
-                            {{ .Site.Params.education.title | default "Education" }}
-                        </a>
-                    </li>
-                    {{ end }}
-
-                    {{ if and (.Site.Params.projects.enable | default false) (not (.Site.Params.navbar.menus.disableProjects | default false)) }}
-                    <li class="nav-item navbar-text">
-                        <a class="nav-link" href="{{ .Site.BaseURL | relURL }}#projects"
-                            aria-label="projects">
-                            {{ .Site.Params.projects.title | default "Projects" }}
-                        </a>
-                    </li>
-                    {{ end }}
-
-                    {{ if and (.Site.Params.achievements.enable | default false) (not (.Site.Params.navbar.menus.disableAchievements | default false)) }}
-                    <li class="nav-item navbar-text">
-                        <a class="nav-link" href="{{ .Site.BaseURL | relURL }}#achievements"
-                            aria-label="achievements">
-                            {{ .Site.Params.achievements.title | default "Achievements" }}
-                        </a>
-                    </li>
-                    {{ end }}
-
-                    {{ if and (.Site.Params.contact.enable | default false) (not (.Site.Params.navbar.menus.disableContact | default false)) }}
-                    <li class="nav-item navbar-text">
-                        <a class="nav-link" href="{{ .Site.BaseURL | relURL }}#contact"
-                            aria-label="contact">
-                            {{ .Site.Params.contact.title | default "Contact" }}
-                        </a>
-                    </li>
+                            <li class="nav-item navbar-text">
+                                <a class="nav-link" href="{{ site.BaseURL | relURL }}#{{ $id }}" aria-label="${{ $id }}">
+                                    {{ $title }}
+                                </a>
+                            </li>
+                        {{ end }}
                     {{ end }}
 
                     {{ if and .Site.Menus.main (.Site.Params.navbar.enableSeparator | default false) }}

--- a/layouts/partials/sections/hero/index.html
+++ b/layouts/partials/sections/hero/index.html
@@ -1,28 +1,20 @@
-{{ if .Site.Params.hero.enable | default false }}
-<section id="hero" class="py-5 align-middle">
+{{ if .enable | default false }}
+<section id="{{ .id | default .type }}" class="hero py-5 align-middle">
     <div class="container px-3 px-sm-5 px-md-5 px-lg-5 pt-lg-3">
         <div class="row">
             <div class="col-sm-12 col-md-12 col-lg-8 content {{ if .Site.Params.animate }}animate{{ end }}" id="primary-font">
-                <span class="subtitle">
-                    {{ .Site.Params.hero.intro }}
-                </span>
-                <h2>
-                    {{ .Site.Params.hero.title }}
-                </h2>
-                <h3>
-                    {{ .Site.Params.hero.subtitle }}
-                </h3>
-                <p class="hero-content">
-                    {{ .Site.Params.hero.content | markdownify }}
-                </p>
+                <span class="subtitle">{{ .intro }}</span>
+                <h2>{{ .title }}</h2>
+                <h3>{{ .subtitle }}</h3>
+                <p class="hero-content">{{ .content | markdownify }}</p>
                 <div class="row">
                     <div class="col-auto h-100">
-                        {{ if .Site.Params.hero.button.enable }}
-                        <a href="{{ .Site.Params.hero.button.url }}" class="btn" {{ cond .Site.Params.hero.button.download "download" "" }}
-			  {{ if .Site.Params.hero.button.newPage | default true }}
-                          target="_blank"
-                          {{ end }}>
-                            {{ .Site.Params.hero.button.name }}
+                        {{ if .button.enable }}
+                        <a href="{{ .button.url }}" class="btn" {{ cond .button.download "download" "" }}
+                            {{ if .button.newPage | default true }}
+                                target="_blank"
+                            {{ end }}>
+                           {{ .button.name }}
                         </a>
                         {{ end }}
                     </div>
@@ -34,8 +26,8 @@
             <div class="col-sm-12 col-md-12 col-lg-4">
                 <div class="row justify-content-center">
                     <div class="col-sm-12 col-md-9 pt-5 image {{ if .Site.Params.animate }}animate{{ end }} px-5 px-md-5 px-lg-0 text-center">
-                        <img src="{{ .Site.Params.hero.image }}"
-                            class="img-thumbnail mx-auto{{ if .Site.Params.hero.roundImage }} rounded-circle{{ end }}"
+                        <img src="{{ .image }}"
+                            class="img-thumbnail mx-auto{{ if .roundImage }} rounded-circle{{ end }}"
                             alt=""
                         >
                     </div>
@@ -43,7 +35,7 @@
             </div>
         </div>
     </div>
-    {{ if .Site.Params.hero.bottomImage.enable | default true }}
+    {{ if .bottomImage.enable | default true }}
     <div class="hero-bottom-svg d-md-block d-lg-block d-none">
         <svg xmlns="http://www.w3.org/2000/svg" width="201" height="201" viewBox="0 0 201 201">
             <g id="Group_1168" data-name="Group 1168" transform="translate(-384 -1392)">

--- a/layouts/partials/sections/hero/social.html
+++ b/layouts/partials/sections/hero/social.html
@@ -1,5 +1,5 @@
 <span>
-    {{ range .Site.Params.hero.socialLinks.fontAwesomeIcons }}
+    {{ range .socialLinks.fontAwesomeIcons }}
     <span class="px-1">
         <a href="{{ .url }}"
             {{ if not (hasPrefix .url "#") }} target="_blank" {{ end }}
@@ -10,7 +10,7 @@
     </span>
     {{ end }}
 
-    {{ range .Site.Params.hero.socialLinks.customIcons }}
+    {{ range .socialLinks.customIcons }}
     <span class="px-1">
         <a href="{{ .url }}"
             {{ if not (hasPrefix .url "#") }} target="_blank" {{ end }}

--- a/layouts/partials/sections/projects.html
+++ b/layouts/partials/sections/projects.html
@@ -1,9 +1,8 @@
-{{ if .Site.Params.projects.enable | default false }}
-<section id="projects" class="py-5">
+<section id="{{ .id | default .type }}" class="projects py-5">
     <div class="container">
-        <h3 class="text-center">{{ .Site.Params.projects.title | default "Projects" }}</h3>
+        <h3 class="text-center">{{ .title | default (strings.FirstUpper .type) }}</h3>
         <div class="row justify-content-center px-3 px-md-5">
-            {{ range .Site.Params.projects.items }}
+            {{ range .items }}
             <div class="col-lg-4 col-md-6 my-3">
                 <div class="card my-3 h-100" title="{{ .title }}">
                     <div class="card-head">
@@ -41,7 +40,7 @@
                 </div>
             </div>
             {{ end }}
-            {{ range ( where .Site.RegularPages "Type" "projects" ) }}
+            {{ range ( where site.RegularPages "Type" "projects" ) }}
             {{ if .Params.showInHome | default true }}
             <div class="col-lg-4 col-md-6 my-3">
                 <div class="card my-3 h-100" title="{{ .Title }}">
@@ -80,4 +79,3 @@
         </div>
     </div>
 </section>
-{{ end }}

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -11,7 +11,7 @@
 {{ end }}
 
 {{ define "main" }}
-<div class="container pt-5" id="projects">
+<div class="projects container pt-5">
     <h2 class="text-center pb-2">{{.Title}}</h2>
     <div class="row">
         {{ range .Paginator.Pages }}

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -64,73 +64,73 @@ header .navbar.animate {
 .tooltip-inner {
     line-height: 1rem;
 }
-.tooltip .tooltip-arrow { 
+.tooltip .tooltip-arrow {
     visibility: hidden !important;
 }
 
 /* hero */
 
-#hero {
+.hero {
     min-height: 100vh;
     line-height: 2rem;
     max-width: 100%;
 }
-#hero .content.animate {
+.hero .content.animate {
     animation: fade-left 1s ease-out;
 }
 
-#hero .hero-bottom-svg {
+.hero .hero-bottom-svg {
     opacity: 0.5;
     position: absolute;
     bottom: -50px;
     left: -150px;
 }
 
-#hero .subtitle {
+.hero .subtitle {
     font-size: clamp(14px,5vw,16px);
     opacity: 0.6;
 }
 
-#hero h2 {
+.hero h2 {
     font-size: clamp(40px, 8vw, 80px);
     color: var(--primary-color) !important;
 }
 
-#hero h3 {
+.hero h3 {
     font-size: clamp(40px, 8vw, 60px);
     /* color: var(--primary-color) !important; */
     opacity: 0.5;
 }
 
-#hero p {
+.hero p {
     margin: 20px 0px 0px;
     max-width: 640px;
     opacity: 0.8;
 }
 
-#hero .image img {
+.hero .image img {
     box-shadow:0px 8px 56px rgba(15, 80, 100, 0.16);
     padding: 0;
     border: 3px solid var(--secondary-color);
     border-radius: 1rem;
 }
 
-#hero .image.animate img {
+.hero .image.animate img {
     animation: fade-in 1s ease-out;
     transition: box-shadow 0.3s;
 }
 
-#hero .image img:hover {
+.hero .image img:hover {
     cursor: pointer;
 }
 
-#hero .image.animate img:hover {
+.hero .image.animate img:hover {
     box-shadow: 0 0 11px rgb(15 80 100 / 20%);
     filter: contrast(1.2);
     cursor: pointer;
 }
 
-#hero a.btn.social-icon {
+.hero a.btn.social-icon {
     color: var(--primary-color) !important;
     line-height: 0%;
     border-radius: 50%;
@@ -140,15 +140,15 @@ header .navbar.animate {
     transition: none;
 }
 
-#hero a.btn.social-icon img {
+.hero a.btn.social-icon img {
     width: 1em;
 }
 
-#hero a.btn.social-icon:hover {
+.hero a.btn.social-icon:hover {
     opacity: 0.8;
 }
 
-#hero a.btn {
+.hero a.btn {
     margin-top: 50px;
     padding: 0.7rem 1.75rem;
     border: 1px solid var(--primary-color);
@@ -157,28 +157,28 @@ header .navbar.animate {
     transition: none;
 }
 
-#hero a.btn:focus {
+.hero a.btn:focus {
     box-shadow: none;
 }
 
-#hero a.btn:hover {
+.hero a.btn:hover {
     background-color: var(--secondary-color) !important;
     color: var(--text-color) !important;
     opacity: 0.9;
 }
 
-#hero a.btn.social-icon:hover {
+.hero a.btn.social-icon:hover {
     background-color: var(--background-color) !important;
     opacity: 0.7;
 }
 
-#hero .hero-content > a {
+.hero .hero-content > a {
     display: inline-block;
     text-decoration: none;
     color: var(--primary-color) !important;
 }
 
-#hero .hero-content > a::after {
+.hero .hero-content > a::after {
     content: "";
     display: block;
     width: 0px;
@@ -189,29 +189,29 @@ header .navbar.animate {
     opacity: 0.5;
 }
 
-#hero .hero-content > a:hover::after, #hero .hero-content > a:focus::after, #hero .hero-content > a:active::after {
+.hero .hero-content > a:hover::after, .hero .hero-content > a:focus::after, .hero .hero-content > a:active::after {
     width: 100%;
 }
 
 
 
 /* about me */
-#about h3 {
+.about h3 {
     color: var(--text-secondary-color) !important;
 }
 
-#about .image img {
+.about .image img {
     box-shadow: 0px 8px 56px rgba(15, 80, 100, 0.16);
     transition: box-shadow 0.3s;
     padding: 0;
     border: 0;
 }
 
-#about .image img:hover {
+.about .image img:hover {
     box-shadow: 0 0 11px rgb(15 80 100 / 20%);
 }
 
-#about ul {
+.about ul {
     display: grid;
     grid-template-columns: repeat(2, minmax(140px, 200px));
     gap: 0px 10px;
@@ -221,32 +221,32 @@ header .navbar.animate {
     list-style: none;
 }
 
-#about ul li {
+.about ul li {
     position: relative;
     margin-bottom: 10px;
     padding-left: 20px;
 }
 
-#about ul li::before {
+.about ul li::before {
     content: "▹";
     color: var(--primary-color);
     position: absolute;
     left: 0px;
 }
 
-#about .content {
+.about .content {
     font-weight: 500;
     opacity: 0.9 !important;
     line-height: 1.7rem !important;
 }
 
-#about a {
+.about a {
     display: inline-block;
     text-decoration: none;
     color: var(--primary-color) !important;
 }
 
-#about a::after {
+.about a::after {
     content: "";
     display: block;
     width: 0px;
@@ -257,75 +257,75 @@ header .navbar.animate {
     opacity: 0.5;
 }
 
-#about a:hover::after, #about a:focus::after, #about a:active::after {
+.about a:hover::after, .about a:focus::after, .about a:active::after {
     width: 100%;
 }
 
 /* experience */
 
-#experience h3 {
+.experience h3 {
     color: var(--text-secondary-color) !important;
 }
 
-#experience * {
+.experience * {
     background-color: transparent !important;
 }
 
-#experience .tab-pane > * {
+.experience .tab-pane > * {
     opacity: 0.9;
 }
 
-#experience .tab-pane small {
+.experience .tab-pane small {
     opacity: 0.8;
 }
 
-#experience .tab-pane ul {
+.experience .tab-pane ul {
     padding-top: 1%;
     padding-bottom: 1%;
 }
 
-#experience .experience-container .tab-content > .tab-pane p {
+.experience .experience-container .tab-content > .tab-pane p {
     padding: 1% 0;
     margin: 0;
 }
 
-#experience .experience-container {
+.experience .experience-container {
     background-color: var(--secondary-color) !important;
     border-radius: .75rem;
     box-shadow: 0px 8px 56px rgb(15 80 100 / 16%);
 }
 
-#experience .nav-item .nav-link {
+.experience .nav-item .nav-link {
     color: var(--text-color) !important;
-    border-bottom: 2px solid transparent; 
+    border-bottom: 2px solid transparent;
     border-radius: 0%;
     transition: none;
     cursor: pointer;
 }
 
-#experience .nav-item .nav-link.active {
+.experience .nav-item .nav-link.active {
     color: var(--text-color) !important;
-    border-bottom: 2px solid var(--primary-color); 
-    opacity: 0.8;
-}
-
-#experience .nav-item .nav-link.active:hover { 
-    transition: none !important;
-}
-
-#experience .nav-item .nav-link:hover {
     border-bottom: 2px solid var(--primary-color);
     opacity: 0.8;
 }
 
-#experience a {
+.experience .nav-item .nav-link.active:hover {
+    transition: none !important;
+}
+
+.experience .nav-item .nav-link:hover {
+    border-bottom: 2px solid var(--primary-color);
+    opacity: 0.8;
+}
+
+.experience a {
     opacity: 0.9;
     display: inline-block;
     text-decoration: none;
     color: var(--primary-color) !important;
 }
 
-#experience a::after {
+.experience a::after {
     content: "";
     display: block;
     width: 0px;
@@ -336,30 +336,30 @@ header .navbar.animate {
     opacity: 0.5;
 }
 
-#experience a:hover::after, #experience a:focus::after, #experience a:active::after {
+.experience a:hover::after, .experience a:focus::after, .experience a:active::after {
     width: 100%;
 }
 
-#experience .experience-container .tab-content .tab-pane ul {
+.experience .experience-container .tab-content .tab-pane ul {
     overflow: hidden;
     list-style: none;
     margin-bottom: 0;
 }
 
-#experience .experience-container .tab-content .tab-pane ul li {
+.experience .experience-container .tab-content .tab-pane ul li {
     position: relative;
     margin-bottom: 10px;
     padding-left: 20px;
 }
 
-#experience .experience-container .tab-content .tab-pane ul li::before {
+.experience .experience-container .tab-content .tab-pane ul li::before {
     content: "▹";
     color: var(--primary-color);
     position: absolute;
     left: 0px;
 }
 
-#experience .experience-container .tab-content .tab-pane .featuredLink a::after {
+.experience .experience-container .tab-content .tab-pane .featuredLink a::after {
     display: block;
     width: auto;
     height: auto;
@@ -369,28 +369,28 @@ header .navbar.animate {
     opacity: 1;
 }
 
-#experience .experience-container .tab-content .tab-pane .featuredLink a.btn {
+.experience .experience-container .tab-content .tab-pane .featuredLink a.btn {
     border: 1px solid var(--primary-color);
     border-radius: .75rem;
     transition: none;
 }
 
-#experience .experience-container .tab-content .tab-pane .featuredLink a.btn:focus {
+.experience .experience-container .tab-content .tab-pane .featuredLink a.btn:focus {
     box-shadow: none;
 }
 
-#experience .experience-container .tab-content .tab-pane .featuredLink a.btn:hover {
+.experience .experience-container .tab-content .tab-pane .featuredLink a.btn:hover {
     color: var(--text-color) !important;
     opacity: 0.7;
 }
 
 /* Education */
 
-#education .container > h3 {
+.education .container > h3 {
     color: var(--text-secondary-color) !important;
 }
 
-#education .row .index {
+.education .row .index {
     opacity: 0.8;
     padding: 13px 20px;
     line-height: 0%;
@@ -402,11 +402,11 @@ header .navbar.animate {
     font-weight: bold;
 }
 
-#education .card * {
+.education .card * {
     background-color: var(--secondary-color) !important;
 }
 
-#education .card {
+.education .card {
     border-radius: 1.5rem;
     box-shadow: 0px 8px 56px rgb(15 80 100 / 16%);
     border: 2px solid var(--text-secondary-color) !important;
@@ -414,36 +414,36 @@ header .navbar.animate {
     transition: transform 0.2s;
 }
 
-#education .card .card-body {
+.education .card .card-body {
     border-radius: 1.5rem;
     padding: 2rem;
 }
 
 @media all and (max-width:768px) {
-    #education .card .card-body {
+    .education .card .card-body {
         padding: 2rem 1rem;
     }
 }
 
-#education .card:hover {
+.education .card:hover {
     transition: 0.3s;
     box-shadow: 0 4px 11px rgb(15 80 100 / 16%);
     border: 2px solid var(--primary-color) !important;
 }
 
-#education .card .card-body .education-content a {
+.education .card .card-body .education-content a {
     color: var(--primary-color) !important;
     text-decoration: none;
     opacity: 0.9;
 }
 
-#education .card .card-body > a h6 {
+.education .card .card-body > a h6 {
     display: inline-block;
     text-decoration: none;
     color: var(--primary-color) !important;
 }
 
-#education .card .card-body > a h6::after {
+.education .card .card-body > a h6::after {
     content: "";
     display: block;
     width: 0px;
@@ -454,11 +454,11 @@ header .navbar.animate {
     opacity: 0.5;
 }
 
-#education .card .card-body > a h6:hover::after, #education .card .card-body > a h6:focus::after, #education .card .card-body > a h6:active::after {
+.education .card .card-body > a h6:hover::after, .education .card .card-body > a h6:focus::after, .education .card .card-body > a h6:active::after {
     width: 100%;
 }
 
-#education .card .card-body a.btn {
+.education .card .card-body a.btn {
     opacity: 0.9;
     border: 1px solid var(--primary-color) !important;
     color: var(--text-color) !important;
@@ -467,21 +467,21 @@ header .navbar.animate {
     transition: none;
 }
 
-#education .card .card-body a.btn:hover {
+.education .card .card-body a.btn:hover {
     opacity: 0.8;
 }
 
 /* achievements */
 
-#achievements a {
+.achievements a {
     text-decoration: none;
 }
 
-#achievements h3 {
+.achievements h3 {
     color: var(--text-secondary-color) !important;
 }
 
-#achievements .card {
+.achievements .card {
     cursor: context-menu;
     background-color: var(--secondary-color) !important;
     border-radius: 1rem;
@@ -491,40 +491,40 @@ header .navbar.animate {
     border: 2px solid transparent;
 }
 
-#achievements a.card {
+.achievements a.card {
     cursor: alias;
 }
 
-#achievements .card h5 {
+.achievements .card h5 {
     color: var(--text-color) !important;
     opacity: 0.9;
 }
 
-#achievements .card:hover {
+.achievements .card:hover {
     border: 2px solid var(--text-color);
     transition: .3s;
 }
-#achievements .card:focus {
+.achievements .card:focus {
     border: 2px solid var(--text-color);
     transition: .3s;
 }
 
-#achievements .card-text {
+.achievements .card-text {
     background-color: var(--secondary-color) !important;
     color: var(--text-secondary-color) !important;
 }
 
-#achievements img {
+.achievements img {
     border-radius: 0.7rem;
 }
 
 /* contact */
 
-#contact h3 {
+.contact h3 {
     color: var(--text-secondary-color) !important;
 }
 
-#contact .btn {
+.contact .btn {
     transition: none;
     transition: opacity 0.3s;
     border-radius: .5rem !important;
@@ -533,15 +533,15 @@ header .navbar.animate {
     color: var(--text-color) !important;
 }
 
-#contact .btn:hover {
+.contact .btn:hover {
     opacity: .7;
 }
 
-#contact .btn:focus {
+.contact .btn:focus {
     box-shadow: none !important;
 }
 
-#contact form .form-control {
+.contact form .form-control {
     background-color: var(--secondary-color);
     color: var(--text-color);
     border-radius: .7rem;
@@ -549,7 +549,7 @@ header .navbar.animate {
     box-shadow: 0px 8px 56px rgb(15 80 100 / 5%);
 }
 
-#contact-form-status {
+.contact-form-status {
     position: fixed;
     bottom: 10px;
     right: 10px;
@@ -557,12 +557,12 @@ header .navbar.animate {
     transform: translate3d(0, 0, 0);
 }
 
-#contact-form-status svg {
+.contact-form-status svg {
     height: 18px;
     width: 18px;
 }
 
-#contact-form-status button {
+.contact-form-status button {
     border-radius: 50%;
     border: none;
     background-color: white;
@@ -572,7 +572,7 @@ header .navbar.animate {
     font-size: .6rem !important;
 }
 
-#contact-form-status .alert {
+.contact-form-status .alert {
     border-radius: 0.5rem;
     box-shadow: 0px 8px 56px rgb(15 80 100 / 5%);
     padding: .5rem 1rem;

--- a/static/css/projects.css
+++ b/static/css/projects.css
@@ -1,21 +1,21 @@
 /* projects */
 
-#projects h3 {
+.projects h3 {
     color: var(--text-secondary-color) !important;
 }
 
-#projects a {
+.projects a {
     text-decoration: none;
     color: var(--text-color) !important;
 }
 
-#projects .badge {
+.projects .badge {
     background-color: var(--background-color) !important;
     color: var(--text-color) !important;
     margin: 0 1%;
 }
 
-#projects .card {
+.projects .card {
     background-color: var(--secondary-color) !important;
     box-shadow: 0px 8px 56px rgb(15 80 100 / 16%);
     min-height: 400px;
@@ -24,13 +24,13 @@
     border: none !important;
 }
 
-#projects .card:hover {
+.projects .card:hover {
     box-shadow: 0 0 11px rgb(15 80 100 / 20%);
     transition: transform 0.3s;
     transform: translateY(-7px);
 }
 
-#projects .card .card-head {
+.projects .card .card-head {
     -o-object-fit: cover;
     object-fit: cover;
     overflow: hidden;
@@ -39,26 +39,26 @@
     border: none !important;
 }
 
-#projects .card .card-footer {
+.projects .card .card-footer {
     border-bottom-left-radius: 1rem;
     border-bottom-right-radius: 1rem;
 }
 
-#projects .card:hover .card-img-top {
+.projects .card:hover .card-img-top {
     transform: scale(1.2);
     transition: all 0.3s ease-out;
 }
 
-#projects .card-img-top {
+.projects .card-img-top {
     transition: transform 0.3s;
 }
 
-#projects .float-end .btn {
+.projects .float-end .btn {
     transition: none;
     border-radius: .5rem !important;
     border-color: var(--primary-color) !important;
 }
 
-#projects .float-end .btn:focus {
+.projects .float-end .btn:focus {
     box-shadow: none !important;
 }


### PR DESCRIPTION
This change enables theme user to specify arbitrary order of sections, and add multiple sections of the same type (more generic approach than in #105, which is applicable only to experience blocks).

- All sections are specified in config as a list, with order of items directly reflecting order on the main page (including navbar).
- Type of a section is specified with a new `type` field.
- If there are multiple sections of the same type, in order to distinguish them for navbar navigation, you need to specify unique `id` field.
- Navbar and main page generation is more generic, allowing to add custom section types – the only requirement is a custom partial named after the section type. Styling can be provided in a custom CSS (enabled with `customCSS` site param).